### PR TITLE
Invisibles are set to the background color.

### DIFF
--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -12,7 +12,7 @@
 // Guide colors
 @syntax-wrap-guide-color: @light-gray-blue;
 @syntax-indent-guide-color: @light-gray-blue;
-@syntax-invisible-character-color: @dark-gray-blue;
+@syntax-invisible-character-color: @light-gray-blue;
 
 // For find and replace markers
 @syntax-result-marker-color: @light-gray-blue;


### PR DESCRIPTION
Currently, invisibles match the background, so they can't be seen even if Settings:Show Invisibles is checked. This PR sets invisibles to `light-gray-blue` so that they are visible against the background. This helps for just about anything where whitespace matters (e.g. Make, Python), while keeping it reasonably subtle.]
